### PR TITLE
Bypass shlex usage if command string begins with +

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,9 @@ Here’s the roadmap to 1.0 release and our current status:
        it’s hacked, but heh, better than nothing)
 -  \[x\] If evaluating through a shell, automatically add said shell to
        ``allowlist_externals`` section
+-  \[x\] Use the command string as is if 1st character in the command string
+       is the + char (immediately after initial backtick). Bypasses the use
+       of shlex.split() before handing off to tox_env.execute().
 -  \[x\] Have a working package
 -  \[ \] Write user documentation
 

--- a/src/tox_backtick/__init__.py
+++ b/src/tox_backtick/__init__.py
@@ -6,6 +6,7 @@
 
 from .__about__ import * ; del __about__  # noqa
 
+from tox.config.cli.parser import ToxParser
 from tox.config.sets import EnvConfigSet
 from tox.plugin import impl
 from tox.session.state import State
@@ -32,5 +33,18 @@ def tox_add_env_config(env_conf: EnvConfigSet, state: State) -> None:
 def tox_before_run_commands(tox_env: ToxEnv) -> None:
     """Eval and replace backquotes expressions"""
     set_env = tox_env.conf["set_env"]
-    set_env.update({var: eval_backquote(tox_env, cmd, var)
+    dont_strip_nl = tox_env.options.backtick_no_strip if 'backtick_no_strip' in tox_env.options else False
+    set_env.update({var: eval_backquote(tox_env, cmd, var, not dont_strip_nl)
                     for var, cmd in set_env_backquote_items(set_env)})
+
+
+@impl
+def tox_add_option(parser: ToxParser) -> None:
+    # have to get the parser for commands that need evaluations of
+    # set_env backticks ?
+    for cmd in ['run', 'exec','run-parallel','legacy' ]:
+        run_parser: ToxParser = parser.handlers[cmd]
+        if run_parser:
+            run_parser[0].add_argument("--backtick-no-strip", action="store_true",
+                                       help="do not strip out LF, CR characters from backtick results",
+                                       dest="backtick_no_strip" ) # default is to strip out the \n\r chars

--- a/src/tox_backtick/test.py
+++ b/src/tox_backtick/test.py
@@ -1,0 +1,100 @@
+import os
+import shutil
+import subprocess
+import tempfile
+from textwrap import dedent
+from unittest import TestCase
+
+from py.iniconfig import IniConfig
+
+from tox.session.cmd.run.parallel import ENV_VAR_KEY as TOX_PARALLEL_ENV
+
+
+class ToxTestCase(TestCase):
+    """A TestCase for testing tox configs. 99% 'borrowed' from tox_factor.
+
+    This class creates a temporary directory, writing the provided contents to
+    the tox config file. The `.config` attribute contains the parsed ini config.
+
+    The test case also provides the `.tox_call()` method for calling tox with
+    the config, and `.tox_envlist()`, which is useful for testing the expected
+    env list.
+
+    Note that the test case doesn't change the working directory or environment.
+
+    Attributes:
+        ini_contents: The contents that will be written to the tox config. This
+            must be set by a test case subclass.
+        ini_filename: The file name to write the tox config contents to. This
+            defaults to 'tox.ini'.
+        ini_filepath: The full path of the temporary tox config file. This is
+            generated during the test case class setup.
+        config: The parsed ini tox config. This is created during the test case
+            class setup.
+        setup_contents: The contents that will be written to the package setup
+            module.
+        setup_filepath: The full path of the temporary setup module. This is
+            generated during the test case class setup.
+    """
+
+    ini_contents = None
+    ini_filename = 'tox.ini'
+
+    setup_contents = None
+
+    @classmethod
+    def setUpClass(cls):
+        super(ToxTestCase, cls).setUpClass()
+
+        assert cls.ini_contents is not None, (
+            '`{cls.__module__}.{cls.__name__}.ini_contents` has not been set.'
+            .format(cls=cls))
+
+        # We can't use the `TemporaryDirectory` context manager since the setup
+        # functions do not wrap the execution of the `test_*` methods. The
+        # directory would have been deleted before the tests are even ran.
+        cls._temp_dir = tempfile.mkdtemp()
+        cls.ini_filepath = os.path.join(cls._temp_dir, cls.ini_filename)
+
+        with open(cls.ini_filepath, 'w') as ini_file:
+            ini_file.write(dedent(cls.ini_contents))
+
+        cls.config = IniConfig(cls.ini_filepath)
+
+        # Create package setup module
+        cls.setup_filepath = os.path.join(cls._temp_dir, 'setup.py')
+        if cls.setup_contents is not None:
+            with open(cls.setup_filepath, 'w') as setup_file:
+                setup_file.write(dedent(cls.setup_contents))
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.config
+        shutil.rmtree(cls._temp_dir)
+
+        super(ToxTestCase, cls).tearDownClass()
+
+    def _tox_call(self, arguments):
+        # Remove TOX_PARALLEL_ENV from the subprocess environment variables.
+        # See: https://github.com/tox-dev/tox/issues/1275
+        env = os.environ.copy()
+        env.pop(TOX_PARALLEL_ENV, None)
+
+        proc = subprocess.Popen(
+            arguments, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
+        stdout, stderr = proc.communicate()
+
+        return proc.returncode, stdout.decode('utf-8'), stderr.decode('utf-8')
+
+    def tox_call(self, arguments):
+        base = ['tox', '-c', self.ini_filepath]
+
+        return self._tox_call(base + arguments)
+
+    def tox_envlist(self, arguments=None):
+        arguments = arguments if arguments else []
+        returncode, stdout, stderr = self.tox_call(['-l'] + arguments)
+
+        self.assertEqual(returncode, 0, stderr)
+
+        return [env for env in stdout.strip().splitlines()]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,275 @@
+import os
+import pytest
+import re
+import unittest
+
+from tox_backtick.test import ToxTestCase
+
+
+class ToxTestCaseTests(unittest.TestCase):
+
+    def test_error_message(self):
+        class Dummy(ToxTestCase):
+            pass
+
+        with self.assertRaises(AssertionError) as excinfo:
+            Dummy.setUpClass()
+
+        self.assertEqual(
+            str(excinfo.exception),
+            '`tests.test_plugin.Dummy.ini_contents` has not been set.',
+        )
+
+    def test_tox_envlist(self):
+        class Dummy(ToxTestCase):
+            ini_contents = """
+            [tox]
+            envlist = py39,py312
+
+            [testenv:lint]
+            """
+
+            def runTest(self):
+                # fixes a Python 2 compatibility issue when instantiating a
+                # test case outside of a test suite
+                pass
+
+        testcase = Dummy()
+
+        try:
+            testcase.setUpClass()
+            envlist = testcase.tox_envlist()
+        finally:
+            testcase.tearDownClass()
+
+        # by default, tox does not list testenvs not present in `envlist`.
+        self.assertEqual(envlist, ['py39', 'py312'])
+
+    def test_tox_call(self):
+        class Dummy(ToxTestCase):
+            ini_contents = """
+            [testenv:lint]
+            commands = python -c "print('clean')"
+            """
+
+            setup_contents = """
+            from setuptools import setup
+
+            setup(name='test')
+            """
+
+            def runTest(self):
+                # fixes a Python 2 compatibility issue when instantiating a
+                # test case outside of a test suite
+                pass
+
+        testcase = Dummy()
+
+        try:
+            testcase.setUpClass()
+            returncode, stdout, stderr = testcase.tox_call(['run', '-e', 'lint'])
+        finally:
+            testcase.tearDownClass()
+
+        self.assertEqual(returncode, 0)
+        self.assertIn('lint: OK', stdout)
+
+    def test_tox_call_no_setup_module(self):
+        class Dummy(ToxTestCase):
+            ini_contents = """
+            [testenv:lint]
+            commands = python -c "print('clean')"
+            """
+
+            def runTest(self):
+                # fixes a Python 2 compatibility issue when instantiating a
+                # test case outside of a test suite
+                pass
+
+        testcase = Dummy()
+
+        try:
+            testcase.setUpClass()
+            returncode, stdout, stderr = testcase.tox_call(['run', '-e', 'lint'])
+        finally:
+            testcase.tearDownClass()
+
+        self.assertEqual(returncode, 0)
+        self.assertIn('lint: OK', stdout)
+
+
+    def test_argument_present(self):
+        class Dummy(ToxTestCase):
+            ini_contents = """
+            [testenv:lint]
+            commands = python -c "print('clean')"
+            """
+
+            setup_contents = """
+            from setuptools import setup
+
+            setup(name='test')
+            """
+
+            def runTest(self):
+                # fixes a Python 2 compatibility issue when instantiating a
+                # test case outside of a test suite
+                pass
+
+        testcase = Dummy()
+
+        try:
+            testcase.setUpClass()
+            returncode, stdout, stderr = testcase.tox_call(['run', '--help'])
+        finally:
+            testcase.tearDownClass()
+
+        self.assertEqual(returncode, 0)
+        self.assertIn('--backtick-no-strip', stdout)
+
+    def test_backtick_simple1(self):
+        class Dummy(ToxTestCase):
+            ini_contents = """
+            [testenv:lint]
+            set_env=TODAY=`/bin/date`
+            commands = python -c "print('TODAY: \{0}'.format('{env:TODAY:no-date-set}'))"
+            """
+
+            setup_contents = """
+            from setuptools import setup
+
+            setup(name='test')
+            """
+
+            def runTest(self):
+                # fixes a Python 2 compatibility issue when instantiating a
+                # test case outside of a test suite
+                pass
+
+        testcase = Dummy()
+
+        try:
+            testcase.setUpClass()
+            returncode, stdout, stderr = testcase.tox_call(['run', '-e', 'lint'])
+        finally:
+            testcase.tearDownClass()
+
+        self.assertEqual(returncode, 0)
+        # a date-like string detected >= 2025-07-01
+        date_re = r'TODAY.*(AM|PM).* 2[0-1]\d{2}'
+        match = re.search(date_re, stdout)
+        self.assertIsNotNone(match, f"Expected date-like string in output: {stdout} because of backtick evaluation.")
+
+    def test_backtick_not_stripped(self):
+        class Dummy(ToxTestCase):
+            ini_contents = """
+            [testenv:lint]
+            set_env=TODAY=`/bin/date`
+            commands = python -c "print('TODAY: \{0} NEXT LINE'.format('{env:TODAY:no-date-set}'))"
+            """
+
+            setup_contents = """
+            from setuptools import setup
+
+            setup(name='test')
+            """
+
+            def runTest(self):
+                # fixes a Python 2 compatibility issue when instantiating a
+                # test case outside of a test suite
+                pass
+
+        testcase = Dummy()
+
+        try:
+            testcase.setUpClass()
+            # because of the preservaction of newline chars in the backtick evaluation output, there will be parsing
+            # errors
+            returncode, stdout, stderr = testcase.tox_call(['run', '--backtick-no-strip', '-e', 'lint'])
+        finally:
+            testcase.tearDownClass()
+
+        self.assertNotEqual(returncode, 0)
+        self.assertIn('unterminated string literal', stderr)
+
+    # Ugh. Can't seemingly parametrize just 1 test method in a class, so we have to use a separate test method
+    # @pytest.mark.parametrize("tox_option,expected", [('--backtick-no-strip', 1),('', 0)])
+    def test_backtick_literal_not_stripped(self):
+        """
+        Test that backtick evaluation uses the entire string as a literal due to the leading + character
+        :return:
+        """
+        class Dummy(ToxTestCase):
+            ini_contents = """
+            [testenv:lint]
+            set_env=TEST1=`+if [ "$VAR_NOT_SET" != "NONE" ] ; then echo 30 ; else echo 5 ; fi`
+            commands = python -c "print('TEST1:\{0}VALUE'.format('{env:TEST1:0}'))"
+            """
+
+            setup_contents = """
+            from setuptools import setup
+
+            setup(name='test')
+            """
+
+            def runTest(self):
+                # fixes a Python 2 compatibility issue when instantiating a
+                # test case outside of a test suite
+                pass
+
+        testcase = Dummy()
+
+        try:
+            testcase.setUpClass()
+            if 'VAR_NOT_SET' in os.environ:
+                del os.environ['VAR_NOT_SET']
+            args = ['run', '-e', 'lint', '--backtick-no-strip']
+            returncode, stdout, stderr = testcase.tox_call(args)
+        finally:
+            testcase.tearDownClass()
+
+        self.assertEqual(returncode, 1, f"Expected return code {1} but got {returncode}. "
+                                               f"stdout: {stdout}, stderr: {stderr}")
+        self.assertIn('unterminated string literal', stderr)
+
+    def test_backtick_literal_stripped(self):
+        """
+        Test that backtick evaluation uses the entire string as a literal due to the leading + character
+        :return:
+        """
+        class Dummy(ToxTestCase):
+            ini_contents = """
+            [testenv:lint]
+            set_env=TEST1=`+if [ "$VAR_NOT_SET" != "NONE" ] ; then echo 30 ; else echo 5 ; fi`
+            commands = python -c "print('TEST1:\{0}VALUE'.format('{env:TEST1:0}'))"
+            """
+
+            setup_contents = """
+            from setuptools import setup
+
+            setup(name='test')
+            """
+
+            def runTest(self):
+                # fixes a Python 2 compatibility issue when instantiating a
+                # test case outside of a test suite
+                pass
+
+        testcase = Dummy()
+
+        try:
+            testcase.setUpClass()
+            if 'VAR_NOT_SET' in os.environ:
+                del os.environ['VAR_NOT_SET']
+            args = ['run', '-e', 'lint']  #  default action is to strip NL, CR from any backtick output
+            returncode, stdout, stderr = testcase.tox_call(args)
+        finally:
+            testcase.tearDownClass()
+
+        self.assertEqual(returncode, 0, f"Expected return code {0} but got {returncode}. "
+                                               f"stdout: {stdout}, stderr: {stderr}")
+        self.assertIn('TEST1:30', stdout)
+        match = re.search(r'TEST1:30VALUE', stdout)  # did the newline get stripped
+        self.assertIsNotNone(match,
+                             f"Expected TEST1:30VALUE with no NL, CR chars at the end of backtick output: {stdout}")
+


### PR DESCRIPTION
Added some tests to confirm new behaviour. Added backtick_no_strip option.

Hi Adam & Damien,
Thank you both for creating the tox-backtick plugin for Tox 4.x.  I've used the tox-backticks for Tox 3 for a number of years now. Got somewhat hooked on being able to execute conditional logic via Bash statements.  I hope you find my proposed changes in this PR as potentially useful, as I've certainly made use of the revised plugin in my local Tox usage as well as in our CI/CD pipeline automated testing context.  Appreciate you taking a look, hopefully incorporating the PR.
Thanks,
-Steve